### PR TITLE
Avoid triggering observers when using arrays

### DIFF
--- a/src/reactor.js
+++ b/src/reactor.js
@@ -103,6 +103,9 @@ class Signal extends Function {
       write (newValue) {
         // Avoid triggering observers if same value is written
         if (this.value === newValue) return (this.value = newValue)
+        // Avoid triggering observers in case of arrays/objects with same values
+        // Note that arrays with the same elements, but in different order will still trigger
+        if (JSON.stringify(this.value) === JSON.stringify(newValue)) return (this.value = newValue)
         // Save the new value/definition
         const output = (this.value = newValue)
         // Trigger dependents


### PR DESCRIPTION
While using Reactor with arrays, === comparison is not enough.
I just added a JSON.stringify based comparison, so arrays with the same elements and order, will be considered equal. 

When the order is different, they will still be considered different because it might to restrictive.

Maybe an Observer parameter to define what kind of comparison could be the solution(?) 

